### PR TITLE
Fix Shift-JIS lead-byte range in mgs_tool decoder

### DIFF
--- a/tools/mgs_tool.py
+++ b/tools/mgs_tool.py
@@ -442,7 +442,7 @@ def decode_controls_to_placeholders(raw: bytes) -> str:
                 continue
         # Try Shift-JIS 2-byte char
         b = raw[i]
-        if (0x82 <= b <= 0x9F or 0xE0 <= b <= 0xEF) and i + 1 < len(raw):
+        if (0x81 <= b <= 0x9F or 0xE0 <= b <= 0xFC) and i + 1 < len(raw):
             try:
                 ch = raw[i:i+2].decode('shift-jis')
                 result.append(ch)


### PR DESCRIPTION
## Summary

- Correct the lead-byte check in `decode_controls_to_placeholders` from `0x82..0x9F or 0xE0..0xEF` to the standard Shift-JIS range `0x81..0x9F or 0xE0..0xFC`.

Common punctuation (「」【】、。) uses 0x81 as a lead byte; extended kanji uses 0xF0–0xFC. Both ranges were silently falling through to the hex-escape branch, producing strings like `\x81u` in the extracted JSON `text` field instead of `「`.

Round-trip behavior is unchanged because `raw_hex` is authoritative — this only affects the human-readable `text` field that translators work from.

## Test plan
- [x] `「` (0x81 0x75) now decodes to the actual character
- [x] `」`, `あ`, `亜`, `燹` all decode correctly
- [x] Invalid Shift-JIS sequences (e.g. `0xEF 0xBF`, `0xF0 0x40`) still fall through to hex-escape via the existing try/except
- [x] Control codes (`FF 02` → `{name}`) still decoded correctly

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)