### PR TITLE
Load DejaVu font lazily instead of at import time

### DIFF
--- a/tools/font_patch.py
+++ b/tools/font_patch.py
@@ -69,7 +69,6 @@ def _find_font():
     print("\nInstall dejavu fonts or place DejaVuSansMono-Bold.ttf in the current directory.")
     sys.exit(1)
 
-FONT_PATH = _find_font()
 LATIN_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 # Font configurations
@@ -316,7 +315,7 @@ def render_halfwidth_glyphs(tile_pitch, font_size, chars=LATIN_CHARS):
     - Left-aligned within the tile (approximately half-tile width)
     - Vertically centered with a baseline offset tuned to match the original font
     """
-    font = ImageFont.truetype(FONT_PATH, font_size)
+    font = ImageFont.truetype(_find_font(), font_size)
     tiles = {}
 
     for ch in chars:


### PR DESCRIPTION
## Summary

- Remove the module-level `FONT_PATH = _find_font()` call
- Look up the font inside `render_halfwidth_glyphs` (the only caller)

`_find_font` exits with `sys.exit(1)` when DejaVu Sans Mono Bold is missing. Running it at import time meant any command that didn't need the font — `decode-page`, usage/help, plain `import font_patch` — also died.

## Test plan
- [x] `python3 tools/font_patch.py` prints usage instead of exiting
- [x] `import font_patch` succeeds without `FONT_PATH` defined
- [x] `decode_page_cmd` does not reference `_find_font`
- [x] `render_halfwidth_glyphs` still calls `_find_font()` (commands that need the font still error cleanly)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)