### PR TITLE
Make encode_translation strict and surface errors in insert

### DIFF
--- a/tools/mgs_tool.py
+++ b/tools/mgs_tool.py
@@ -407,12 +407,16 @@ CONTROL_DECODE = {v: k for k, v in CONTROL_CODES.items()}
 
 
 def encode_translation(text: str) -> bytes:
-    """Encode a translated string, converting placeholders to FF xx control codes."""
+    """Encode a translated string, converting placeholders to FF xx control codes.
+
+    Raises UnicodeEncodeError if `text` contains any non-ASCII character outside
+    of recognised `{placeholder}` tokens. Callers should catch and surface the
+    error with location context (file, subscript, string index).
+    """
     result = b''
     i = 0
     while i < len(text):
         if text[i] == '{':
-            # Try to match a control code placeholder
             matched = False
             for placeholder, code_bytes in CONTROL_CODES.items():
                 if text[i:i+len(placeholder)] == placeholder:
@@ -421,10 +425,10 @@ def encode_translation(text: str) -> bytes:
                     matched = True
                     break
             if not matched:
-                result += text[i].encode('ascii', errors='replace')
+                result += text[i].encode('ascii')
                 i += 1
         else:
-            result += text[i].encode('ascii', errors='replace')
+            result += text[i].encode('ascii')
             i += 1
     return result
 
@@ -481,6 +485,7 @@ def insert_translations(translations_json: str, original_dir: str, output_dir: s
     patched_files = 0
     patched_strings = 0
     skipped_strings = 0
+    encoding_errors = []
 
     for filename, subs_data in trans_data.get('files', {}).items():
         filepath = os.path.join(original_dir, filename)
@@ -498,7 +503,17 @@ def insert_translations(translations_json: str, original_dir: str, output_dir: s
             for entry in sub_data['entries']:
                 if 'translation' in entry and entry['translation']:
                     trans_text = entry['translation']
-                    trans_bytes = encode_translation(trans_text)
+                    try:
+                        trans_bytes = encode_translation(trans_text)
+                    except UnicodeEncodeError as e:
+                        bad = trans_text[e.start]
+                        encoding_errors.append(
+                            f'  {filename} / {sub_name} / entry {entry["index"]}: '
+                            f'non-ASCII {bad!r} (U+{ord(bad):04X}) at position {e.start} '
+                            f'in {trans_text!r}'
+                        )
+                        skipped_strings += 1
+                        continue
                     if sub_name not in trans_map:
                         trans_map[sub_name] = {}
                     trans_map[sub_name][entry['index']] = trans_bytes
@@ -553,6 +568,12 @@ def insert_translations(translations_json: str, original_dir: str, output_dir: s
 
     print(f'Inserted {patched_strings} translations across {patched_files} files')
     print(f'Skipped {skipped_strings} untranslated strings')
+    if encoding_errors:
+        print(f'\n{len(encoding_errors)} translations skipped due to non-ASCII characters:')
+        for err in encoding_errors[:20]:
+            print(err)
+        if len(encoding_errors) > 20:
+            print(f'  ... and {len(encoding_errors) - 20} more')
     print(f'Output written to {output_dir}')
 
 


### PR DESCRIPTION
## Summary

- `encode_translation` no longer uses `errors='replace'`; non-ASCII characters now raise `UnicodeEncodeError`
- `insert_translations` catches per translation, records the file / subscript / entry index + the offending character + code point, skips that one translation, and continues
- At the end of insert, a summary lists the first 20 bad translations so the translator can fix them in one pass

Previously a stray em-dash, smart quote, accented character, or forgotten Japanese character was silently replaced with `?` and shipped into the patched file. The translator saw no error; the glitch only surfaced in-game.

## Example output

```
Inserted 1234 translations across 12 files
Skipped 56 untranslated strings

3 translations skipped due to non-ASCII characters:
  EVE.mgp / EVE_001 / entry 42: non-ASCII '—' (U+2014) at position 15 in 'Hello — world'
  EVE.mgp / EVE_003 / entry 7:  non-ASCII '"' (U+201C) at position 0 in '"quoted"'
  aku_00.mgs / aku_00 / entry 91: non-ASCII 'こ' (U+3053) at position 0 in 'こんにちは'
Output written to patched/Script
```

## Test plan
- [x] ASCII input with placeholders still works (`'Hello {name}' → b'Hello \xff\x02'`)
- [x] Em-dash raises `UnicodeEncodeError` at the offending position
- [x] Smart quotes raise
- [x] Hiragana raises
- [x] Unknown `{placeholder}` still passes through unchanged (tracked separately in #9)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)