### PR TITLE
Filter non-script files from insert_translations leftover copy

### DIFF
--- a/tools/mgs_tool.py
+++ b/tools/mgs_tool.py
@@ -545,11 +545,16 @@ def insert_translations(translations_json: str, original_dir: str, output_dir: s
             f.write(rebuilt)
         patched_files += 1
 
-    # Copy any files from original_dir that weren't in translations
+    # Copy any .mgs / .mgp files from original_dir that weren't in translations
     for filename in os.listdir(original_dir):
+        if not (filename.endswith('.mgs') or filename.endswith('.mgp')):
+            continue
+        src = os.path.join(original_dir, filename)
+        if not os.path.isfile(src):
+            continue
         outpath = os.path.join(output_dir, filename)
         if not os.path.exists(outpath):
-            shutil.copy2(os.path.join(original_dir, filename), outpath)
+            shutil.copy2(src, outpath)
 
     print(f'Inserted {patched_strings} translations across {patched_files} files')
     print(f'Skipped {skipped_strings} untranslated strings')


### PR DESCRIPTION
## Summary

The leftover-copy loop iterated every entry in `original_dir` and `shutil.copy2`d anything missing from `output_dir`. That silently copied non-script files (README, stray binaries) into the patched output, and crashed with `IsADirectoryError` on subdirectories.

Filtered to `.mgs` / `.mgp` files (matching the `extract_all` filter two screens up), with an extra `os.path.isfile` guard.

## Test plan
- [x] Mixed directory with `A.mgs`, `B.mgp`, `README.txt`, and `subdir/` → output contains only `A.mgs` and `B.mgp`
- [x] No `IsADirectoryError` from the subdirectory

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)