### PR TITLE
Add regression suite for 0.1 fixes; correct encode_translation error position

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+pythonpath = .
+addopts = -q

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,0 +1,135 @@
+"""Regression tests for the 0.1 fixes (PRs #12–#23).
+
+Each test locks in exactly one invariant introduced or tightened in that
+release. Run from the repo root: ``pytest``.
+"""
+import json
+import struct
+
+import pytest
+
+from tools.mgs_tool import (
+    decode_controls_to_placeholders,
+    encode_translation,
+    insert_translations,
+    parse_subscript,
+)
+from tools.xbe_tool import SECTIONS, _check_raw_hex_match, _validate_xbe_sections
+
+
+# PR #12 — Shift-JIS lead-byte range
+def test_sjis_lead_byte_range():
+    # 0x81 was outside the old range (0x82..0x9F); must now decode as one SJIS
+    # char. 0x81 0x40 is the SJIS-encoded full-width ideographic space U+3000.
+    decoded_81 = decode_controls_to_placeholders(b"\x81\x40")
+    assert decoded_81 == "\u3000", f"0x81 0x40 should decode as U+3000, got {decoded_81!r}"
+
+    # 0xA0 is single-byte halfwidth; it must NOT consume the following 0x41 as
+    # a trail byte — the "A" has to survive.
+    decoded_a0 = decode_controls_to_placeholders(b"\xA0\x41")
+    assert decoded_a0.endswith("A"), f"0xA0 must not swallow the following 'A', got {decoded_a0!r}"
+
+
+# PR #14 — strict encode + correct error position
+def test_encode_translation_non_ascii_reports_correct_position():
+    with pytest.raises(UnicodeEncodeError) as exc_info:
+        encode_translation("héllo world")
+    e = exc_info.value
+    assert e.start == 1, f"expected start=1 ('é' is at index 1), got {e.start}"
+    assert e.end == 2
+    assert e.object == "héllo world"
+    assert e.object[e.start] == "é"
+
+
+# PR #20 — unknown placeholder tokens raise
+def test_encode_translation_unknown_placeholder_raises():
+    with pytest.raises(ValueError, match=r"\bbogus\b"):
+        encode_translation("hi {bogus}")
+
+
+# PR #18 — parse_subscript honours end_limit
+def test_parse_subscript_respects_end_limit():
+    # Two 64-byte regions. First sub-script has off4=96 which points past its
+    # own 64-byte allocation into the second region. With end_limit=64 this
+    # must be rejected; with end_limit=len(data) the old code would accept.
+    first_region = 64
+    data = bytearray(128)
+    struct.pack_into("<H", data, 0, 0x007E)
+    struct.pack_into("<IIII", data, 2, 18, 20, 40, 96)
+
+    assert parse_subscript(bytes(data), 0, first_region) is None
+
+
+# PR #19 — insert_translations only copies .mgs/.mgp leftovers
+def test_insert_translations_filters_leftovers(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "foo.mgs").write_bytes(b"\x7E\x00" + b"\x00" * 62)
+    (src / "bar.mgp").write_bytes(b"\x7E\x00" + b"\x00" * 62)
+    (src / "README.txt").write_text("not a script")
+    nested = src / "nested"
+    nested.mkdir()
+    (nested / "ignore.mgs").write_bytes(b"hi")
+
+    trans = tmp_path / "t.json"
+    trans.write_text(json.dumps({"files": {}}))
+    out = tmp_path / "out"
+    insert_translations(str(trans), str(src), str(out))
+
+    assert (out / "foo.mgs").exists()
+    assert (out / "bar.mgp").exists()
+    assert not (out / "README.txt").exists(), "README.txt must not leak into output"
+    assert not (out / "nested").exists(), "subdirs must not leak into output"
+
+
+# PR #22 — XBE section-layout validation
+def test_validate_xbe_sections_rejects_modified_header():
+    base_addr = 0x10000
+    section_table_file = 0x400
+    section_table_va = base_addr + section_table_file
+    name_table_file = 0x500  # layout: "\x00.rdata\x00.data\x00"
+    buf = bytearray(0x800)
+    buf[:4] = b"XBEH"
+    struct.pack_into("<I", buf, 0x104, base_addr)
+    struct.pack_into("<I", buf, 0x11C, 2)
+    struct.pack_into("<I", buf, 0x120, section_table_va)
+
+    # Layout inside the name table, one byte at a time:
+    #   +0: \x00  +1–6: .rdata  +7: \x00  +8–12: .data  +13: \x00  +14–15: pad
+    buf[name_table_file:name_table_file + 16] = b"\x00.rdata\x00.data\x00\x00\x00"
+    names = {".rdata": name_table_file + 1, ".data": name_table_file + 8}
+    for i, sec in enumerate(SECTIONS):
+        off = section_table_file + i * 0x38
+        vsz = sec["va_end"] - sec["va_start"]
+        raw_size = sec["file_end"] - sec["file_start"]
+        struct.pack_into(
+            "<IIIIII", buf, off,
+            0,
+            sec["va_start"],
+            vsz,
+            sec["file_start"],
+            raw_size,
+            base_addr + names[sec["name"]],
+        )
+
+    _validate_xbe_sections(bytes(buf))  # happy path: no raise
+
+    bad = bytearray(buf)
+    rdata_raw_addr_offset = section_table_file + 0 * 0x38 + 0x0C
+    bad[rdata_raw_addr_offset + 1] ^= 0x0F
+    with pytest.raises(ValueError, match=r"\.rdata"):
+        _validate_xbe_sections(bytes(bad))
+
+
+# PR #15 — cmd_insert raw_hex mismatch detection (via extracted helper)
+def test_check_raw_hex_match_detects_mismatch():
+    # Exact match: the bytes "hi\0" correspond to raw_hex "6869" stored in
+    # the JSON. byte_length=3 includes the null.
+    assert _check_raw_hex_match(b"hi\x00", "6869", 3) is True
+
+    # One-byte mismatch in the first position.
+    assert _check_raw_hex_match(b"HI\x00", "6869", 3) is False
+
+    # Null-terminator alignment: if the slot has no null where expected, the
+    # helper must report a mismatch even when the visible prefix matches.
+    assert _check_raw_hex_match(b"hij", "6869", 3) is False

--- a/tools/mgs_tool.py
+++ b/tools/mgs_tool.py
@@ -450,7 +450,13 @@ def encode_translation(text: str) -> bytes:
             result += b'{'
             i += 1
         else:
-            result += text[i].encode('ascii')
+            try:
+                result += text[i].encode('ascii')
+            except UnicodeEncodeError:
+                raise UnicodeEncodeError(
+                    'ascii', text, i, i + 1,
+                    'non-ASCII character outside of known placeholder'
+                ) from None
             i += 1
     return result
 

--- a/tools/xbe_tool.py
+++ b/tools/xbe_tool.py
@@ -111,6 +111,20 @@ def _validate_xbe_sections(xbe_data):
         )
 
 
+def _check_raw_hex_match(actual: bytes, expected_hex: str, byte_length: int) -> bool:
+    """Check whether the bytes actually present in the XBE at an entry's file_offset
+    still match the raw_hex recorded when that entry was extracted.
+
+    `actual` is a byte_length-long slice of the XBE. `expected_hex` is the
+    raw_hex field from the JSON (string hex, no null terminator). A null byte
+    is appended to the decoded expected bytes before comparison because
+    extracted strings are null-terminated in the XBE but the stored hex omits
+    the null.
+    """
+    expected = bytes.fromhex(expected_hex) + b'\x00'
+    return actual == expected[:byte_length]
+
+
 def file_to_va(file_offset):
     """Convert file offset to virtual address."""
     for sec in SECTIONS:
@@ -511,9 +525,9 @@ def cmd_insert(json_path, original_xbe_path, output_xbe_path):
         replacement = trans_bytes + b'\x00' * (byte_length - len(trans_bytes))
         assert len(replacement) == byte_length
 
-        expected_raw = bytes.fromhex(entry['raw_hex']) + b'\x00'
         actual = bytes(xbe[file_offset:file_offset + byte_length])
-        if actual != expected_raw[:byte_length]:
+        if not _check_raw_hex_match(actual, entry['raw_hex'], byte_length):
+            expected_raw = bytes.fromhex(entry['raw_hex']) + b'\x00'
             mismatches.append({
                 'id': entry['id'],
                 'file_offset': file_offset,


### PR DESCRIPTION
## Summary

- Locks in the seven non-obvious invariants from the 0.1 release (PRs #12, #14, #15, #18, #19, #20, #22) as pytest cases in a new `tests/` dir.
- Fixes an error-reporting bug discovered while re-validating #14: the non-ASCII diagnostic always reported the wrong character/position because `encode_translation` re-raised `UnicodeEncodeError` with `e.start=0` (the index inside the 1-char substring Python was encoding), not the index inside the caller's full translation string.
- Extracts a small `_check_raw_hex_match` helper from `xbe_tool.cmd_insert` so #15's invariant is unit-testable without needing a synthetic XBE fixture. Behaviour-preserving.

## Test plan

- [x] `pytest` — 7 passed in 0.01s
- [x] mgs roundtrip against `Media/Script` (43/43) and `Media/Scriptf` (43/43)
- [x] `insert` with `"héllo world"` as translation → now correctly reports `'é' (U+00E9) at position 1` (was: `'h' (U+0068) at position 0`)
- [x] `insert` with `"hi {bogus}"` → still reports `unrecognized placeholder {bogus} at position 3`
- [x] `xbe_tool extract` on real XBE → 3720 strings
- [x] `xbe_tool extract` on a corrupted header (byte flipped in `.rdata.raw_addr` field) → ABORT with `.rdata.file_start` mismatch
- [x] `xbe_tool insert` with flipped `raw_hex` in JSON → still emits `entries did not match the JSON raw_hex` warning (refactor is behaviour-preserving)
- [x] `font_patch patch-f24` HEAD vs pre-#21 worktree → post-#21 touches 0 bytes in kanji-only blocks; pre-#21 touched 5448
- [x] `font_patch preview 24` output is 5952×120
- [x] `import tools.font_patch` succeeds with `ImageFont.truetype` patched to raise

## Tests

| Test | Locks in |
|------|----------|
| `test_sjis_lead_byte_range` | #12 — 0x81 now decodes as SJIS U+3000; 0xA0 still treated as single-byte |
| `test_encode_translation_non_ascii_reports_correct_position` | #14 — `UnicodeEncodeError.start` is the correct index into the caller's text |
| `test_encode_translation_unknown_placeholder_raises` | #20 — `{bogus}` raises `ValueError` |
| `test_parse_subscript_respects_end_limit` | #18 — off4 past end_limit but inside data is rejected |
| `test_insert_translations_filters_leftovers` | #19 — only `.mgs`/`.mgp` files copied to output |
| `test_validate_xbe_sections_rejects_modified_header` | #22 — tampered `.rdata.raw_addr` raises ValueError |
| `test_check_raw_hex_match_detects_mismatch` | #15 — helper returns False on mismatch, True on exact match + null terminator |

🤖 Generated with [Claude Code](https://claude.com/claude-code)