### PR TITLE
Add .gitignore for Python caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/


### PR DESCRIPTION
## Summary
- Add a minimal `.gitignore` covering `__pycache__/`, `*.pyc`, `*.pyo`, and `.pytest_cache/`.

## Motivation
The repo has never had a `.gitignore`. With the regression suite from [#24](https://github.com/RayCharlizard/smt-nine-tools/pull/24) now in the tree, running `pytest` generates `tests/__pycache__/`, `tools/__pycache__/`, and (when pytest doesn't drop its own internal ignore) `.pytest_cache/`, all of which currently show up as untracked on every `git status`. This keeps the working tree clean without touching anything else.

## Test plan
- [x] `git check-ignore` confirms all four patterns match their intended paths (`tools/__pycache__/`, `tests/__pycache__/foo.pyc`, `.pytest_cache/`, `*.pyc`, `*.pyo`).
- [x] `git status` on a freshly-added `.gitignore` shows a clean tree with only the new file staged.