### PR TITLE
Remove unused pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-testpaths = tests
-pythonpath = .
-addopts = -q


### PR DESCRIPTION
## Summary

Removes the 3-line `pytest.ini` added in #24. pytest 8+ auto-discovers `tests/` when the directory contains an `__init__.py` and handles `sys.path` via rootdir detection, so `testpaths` / `pythonpath` were no-ops. The `-q` default was the only behaviour change, and it's invoked explicitly on the few places that care.

## Test plan

- [x] `pytest` from repo root with the file removed — 7 passed in 0.01s

🤖 Generated with [Claude Code](https://claude.com/claude-code)